### PR TITLE
Fix build on some macOS versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,4 +52,4 @@ Mkfile.old
 Module.symvers
 dkms.conf
 modules.order
-slip39/slip39
+slip39

--- a/Makefile
+++ b/Makefile
@@ -8,10 +8,10 @@ SRCS = hazmat.c randombytes.c sss.c tweetnacl.c \
 	hmac.c memzero.c pbkdf2.c sha2.c
 OBJS := ${SRCS:.c=.o}
 
-ifeq ($(shell uname -o), GNU/Linux)
-LINK := $(AR) -rcs
+ifeq ($(shell uname -s), Darwin)
+LINK := $(shell which libtool) -static -a -o
 else
-LINK := $(which libtool) -static -a -o
+LINK := $(AR) -rcs
 endif
 
 all: libsss.a libslip39.a


### PR DESCRIPTION
Change the platform detection code in the makefile to be a bit more cross-platform, using `uname` options defined on both Linux and various BSD, and invert the order so that unrecognized systems default to Linux rather than macOS conventions. This should fix the build problems @ChristopherA was seeing on some macOS systems.

Also has a minor fix to the `.gitignore` file so that the slip39 binary is ignored.